### PR TITLE
Add /suppress

### DIFF
--- a/server/bot/commands/help.ts
+++ b/server/bot/commands/help.ts
@@ -38,6 +38,7 @@ TP \`/request\` - Request a specific feature.
 \`/editLastSay\` - Even if it was another channel.
 \`/remindme\` - Reminders.
 \`/leave\` - Makes you leave the server.
+\`/suppress\` - Suppress or unsuppress embeds in a message.
 \`/ocr\` - Get text from an image.
 \`/avatar\` - Avatar of a user.
 \`/userinfo\` - User info.

--- a/server/bot/commands/utilities.ts
+++ b/server/bot/commands/utilities.ts
@@ -1,9 +1,5 @@
 // All the types!
-<<<<<<< HEAD
-import Eris, { Message, TextChannel, GuildTextableChannel } from 'eris'
-=======
 import Eris, { Message, GuildTextableChannel } from 'eris'
->>>>>>> 05cda48 (Apply suggestions from code review)
 import { Command } from '../imports/types'
 // All the needs!
 import { getIdFromMention, getInsult, getUser } from '../imports/tools'
@@ -600,7 +596,7 @@ export const handleSuppress: Command = {
       permissions: { manageMessages: true }
     },
     description: 'Suppress or unsuppress embeds in a message.',
-    fullDescription: 'Suppress embeds in a message. If the message already has a suppressed embed, it will get unsuppressed. Requires \'Manage Messages\' permission',
+    fullDescription: 'Suppress or unsuppress embeds in a message.',
     usage: '/suppress (channel) <message ID or link>',
     example: '/suppress #general 123456789012345678'
   },
@@ -612,7 +608,7 @@ export const handleSuppress: Command = {
       if (regex.test(args[0])) {
         const split = args[0].split('/')
         channel = message.member.guild.channels.get(split[5]) as GuildTextableChannel
-        if (!channel) return `That's not a real channel, you ${getInsult()}.`
+        if (!channel || channel.type !== 0) return `That's not a real channel, you ${getInsult()}.`
         msg = channel.messages.get(split[6]) || await channel.getMessage(split[6])
       } else {
         msg = message.channel.messages.get(args[0]) || await message.channel.getMessage(args[0])
@@ -624,14 +620,10 @@ export const handleSuppress: Command = {
         msg = channel.messages.get(args[1]) || await channel.getMessage(args[1])
       } else return `That's not a real channel, you ${getInsult()}.`
     } else return 'Invalid usage.'
+
     if (msg) {
-      const { requestHandler } = client as unknown as {
-        requestHandler: {
-          request: (method: string, url: string, auth: boolean, body: object) => Promise<Object>
-        }
-      }
-      await requestHandler.request('PATCH', `/channels/${channel.id}/messages/${msg.id}`, true, {
-        flags: (msg as unknown as { flags: number }).flags ^ Eris.Constants.MessageFlags.SUPPRESS_EMBEDS
+      await client.requestHandler.request('PATCH', `/channels/${channel.id}/messages/${msg.id}`, true, {
+        flags: msg.flags ^ Eris.Constants.MessageFlags.SUPPRESS_EMBEDS
       })
       message.addReaction('✅')
     } else return `That's not a real message, you ${getInsult()}.`

--- a/server/bot/commands/utilities.ts
+++ b/server/bot/commands/utilities.ts
@@ -1,5 +1,9 @@
 // All the types!
+<<<<<<< HEAD
 import Eris, { Message, TextChannel, GuildTextableChannel } from 'eris'
+=======
+import Eris, { Message, GuildTextableChannel } from 'eris'
+>>>>>>> 05cda48 (Apply suggestions from code review)
 import { Command } from '../imports/types'
 // All the needs!
 import { getIdFromMention, getInsult, getUser } from '../imports/tools'
@@ -606,48 +610,38 @@ export const handleSuppress: Command = {
       let channelToEdit
       const regex = /https?:\/\/((canary|ptb|www).)?discord(app)?.com\/channels\/\d{17,18}\/\d{17,18}\/\d{17,18}/
       if (regex.test(args[0])) {
-        if (!((message.member.guild.channels.get(args[0].split('/')[5]) as TextChannel).messages.get(args[0].split('/')[6]))) {
-          msg = await client.getMessage(args[0].split('/')[5], args[0].split('/')[6])
-          channelToEdit = args[0].split('/')[5]
-        } else {
-          msg = (message.member.guild.channels.get(args[0].split('/')[5]) as TextChannel).messages.get(args[0].split('/')[6])
-          channelToEdit = args[0].split('/')[5]
-        }
+        const split = args[0].split('/')
+        const channel = message.member.guild.channels.get(split[5]) as GuildTextableChannel
+        msg = channel.messages.get(split[6]) || await client.getMessage(split[5], split[6])
+        channelToEdit = split[5]
       } else {
-        if (!(message.channel.messages.get(args[0]))) {
-          msg = await message.channel.getMessage(args[0])
-          channelToEdit = message.channel.id
-        } else {
-          msg = message.channel.messages.get(args[0])
-          channelToEdit = message.channel.id
-        }
+        msg = message.channel.messages.get(args[0]) || await message.channel.getMessage(args[0])
+        channelToEdit = message.channel.id
       }
       if (msg) {
         await (client as unknown as { requestHandler: { request: (method: string, url: string, auth: boolean, body: object) => Promise<Object> } }).requestHandler.request('PATCH', `/channels/${channelToEdit}/messages/${msg.id}`, true, { flags: (msg as unknown as { flags: number }).flags ^ Eris.Constants.MessageFlags.SUPPRESS_EMBEDS })
         message.addReaction('✅')
-      } else {
-        return `That's not a real message, you ${getInsult}`
-      }
+      } else return `That's not a real message, you ${getInsult()}`
     } else if (args.length === 2) {
       const channelToEdit = getIdFromMention(args[0])
       if (message.member.guild.channels.get(channelToEdit).type === 0) {
         let msg
-        if (!((message.member.guild.channels.get(channelToEdit) as TextChannel).messages.get(args[1]))) {
+        if (!((message.member.guild.channels.get(channelToEdit) as GuildTextableChannel).messages.get(args[1]))) {
           msg = await client.getMessage(channelToEdit, args[1])
         } else {
-          msg = (message.member.guild.channels.get(channelToEdit) as TextChannel).messages.get(args[1])
+          msg = (message.member.guild.channels.get(channelToEdit) as GuildTextableChannel).messages.get(args[1])
         }
         if (msg) {
-          await (client as unknown as { requestHandler: { request: (method: string, url: string, auth: boolean, body: object) => Promise<Object> } }).requestHandler.request('PATCH', `/channels/${channelToEdit}/messages/${msg.id}`, true, { flags: (msg as unknown as { flags: number }).flags ^ Eris.Constants.MessageFlags.SUPPRESS_EMBEDS })
+          const { requestHandler } = client as unknown as { requestHandler: {
+              request: (method: string, url: string, auth: boolean, body: object) => Promise<Object>
+            }
+          }
+          await requestHandler.request('PATCH', `/channels/${channelToEdit}/messages/${msg.id}`, true, {
+            flags: (msg as unknown as { flags: number }).flags ^ Eris.Constants.MessageFlags.SUPPRESS_EMBEDS
+          })
           message.addReaction('✅')
-        } else {
-          return `That's not a real message, you ${getInsult}`
-        }
-      } else {
-        return `That's not a real channel, you ${getInsult}`
-      }
-    } else {
-      return 'Invalid usage.'
-    }
+        } else return `That's not a real message, you ${getInsult()}`
+      } else return `That's not a real channel, you ${getInsult()}`
+    } else return 'Invalid usage.'
   }
 }

--- a/server/bot/commands/utilities.ts
+++ b/server/bot/commands/utilities.ts
@@ -613,7 +613,7 @@ export const handleSuppress: Command = {
         const split = args[0].split('/')
         channel = message.member.guild.channels.get(split[5]) as GuildTextableChannel
         if (!channel) return `That's not a real channel, you ${getInsult()}.`
-        msg = channel.messages.get(split[6]) || await channel.getMessage(split[6]
+        msg = channel.messages.get(split[6]) || await channel.getMessage(split[6])
       } else {
         msg = message.channel.messages.get(args[0]) || await message.channel.getMessage(args[0])
         channel = message.channel


### PR DESCRIPTION
This allows anyone with Manage Messages to suppress (or unsuppress!) the embeds on a message. 

Note: The code is slightly messy due to missing typings. Also, it makes use of the request handler to avoid being hit with a DiscordRESTError [50005]